### PR TITLE
Change how app versioning works

### DIFF
--- a/Myra/API/API.swift
+++ b/Myra/API/API.swift
@@ -1130,30 +1130,6 @@ class API {
         }
     }
     
-//    static func updateRemoteVersion(ios: Int, idphint: String, completion: @escaping (_ success: Bool) -> Void) {
-//        guard let r = Reachability(), r.connection != .none else {
-//            Logger.log(message: "Could not update remote versions: app is offline.")
-//            return completion(false)
-//        }
-//        guard let endpoint = URL(string: Constants.API.versionPath, relativeTo: Constants.API.baseURL) else {
-//            return completion(false)
-//        }
-//
-//        var params: [String: Any]  = [String: Any]()
-//        params["ios"] = ios
-//        params["idpHint"] = idphint
-//        API.put(endpoint: endpoint, params: params) { (response) in
-//            if let rsp = response, !rsp.result.isFailure {
-//                return completion(true)
-//            } else {
-//                return completion(false)
-//            }
-//        }
-//    }
-    
-//    static func updateRemoteVersionInAllEnviorments(params: [String: Any], completion: @escaping (_ success: Bool) -> Void) {
-//    }
-    
     static func loadRemoteVersion(completion: @escaping (_ success: Bool) -> Void) {
         guard let r = Reachability(), r.connection != .none else {
             Logger.log(message: "Could not load remote versions: app is offline.")

--- a/Myra/API/API.swift
+++ b/Myra/API/API.swift
@@ -1130,29 +1130,29 @@ class API {
         }
     }
     
-    static func updateRemoteVersion(ios: Int, idphint: String, completion: @escaping (_ success: Bool) -> Void) {
-        guard let r = Reachability(), r.connection != .none else {
-            Logger.log(message: "Could not update remote versions: app is offline.")
-            return completion(false)
-        }
-        guard let endpoint = URL(string: Constants.API.versionPath, relativeTo: Constants.API.baseURL) else {
-            return completion(false)
-        }
-        
-        var params: [String: Any]  = [String: Any]()
-        params["ios"] = ios
-        params["idpHint"] = idphint
-        API.put(endpoint: endpoint, params: params) { (response) in
-            if let rsp = response, !rsp.result.isFailure {
-                return completion(true)
-            } else {
-                return completion(false)
-            }
-        }
-    }
+//    static func updateRemoteVersion(ios: Int, idphint: String, completion: @escaping (_ success: Bool) -> Void) {
+//        guard let r = Reachability(), r.connection != .none else {
+//            Logger.log(message: "Could not update remote versions: app is offline.")
+//            return completion(false)
+//        }
+//        guard let endpoint = URL(string: Constants.API.versionPath, relativeTo: Constants.API.baseURL) else {
+//            return completion(false)
+//        }
+//
+//        var params: [String: Any]  = [String: Any]()
+//        params["ios"] = ios
+//        params["idpHint"] = idphint
+//        API.put(endpoint: endpoint, params: params) { (response) in
+//            if let rsp = response, !rsp.result.isFailure {
+//                return completion(true)
+//            } else {
+//                return completion(false)
+//            }
+//        }
+//    }
     
-    static func updateRemoteVersionInAllEnviorments(params: [String: Any], completion: @escaping (_ success: Bool) -> Void) {
-    }
+//    static func updateRemoteVersionInAllEnviorments(params: [String: Any], completion: @escaping (_ success: Bool) -> Void) {
+//    }
     
     static func loadRemoteVersion(completion: @escaping (_ success: Bool) -> Void) {
         guard let r = Reachability(), r.connection != .none else {

--- a/Myra/UI/Modals and custom UI/Settings/SettingsManager.swift
+++ b/Myra/UI/Modals and custom UI/Settings/SettingsManager.swift
@@ -317,21 +317,19 @@ class SettingsManager {
     /// - Returns: Integer representing application and local database version
     static func generateAppIntegerVersion() -> Int? {
         // We get version and build numbers of app
-        guard let infoDict = Bundle.main.infoDictionary, let version = infoDict["CFBundleShortVersionString"], let build = infoDict["CFBundleVersion"] else {
+        guard let infoDict = Bundle.main.infoDictionary, let version = infoDict["CFBundleShortVersionString"] as? String, let build = infoDict["CFBundleVersion"] as? String  else {
             Logger.log(message: "Could not find build version and number to generate integer app version in settings")
             return nil
         }
+
         // comvert tp integer
-        let stringVersion = "\(version)".removeWhitespaces()
-        let stringBuild = "\(build)".removeWhitespaces()
-        guard let intVersion = Int(stringVersion), let intBuild = Int(stringBuild) else {
+        let versionAsString = "\(version)".removeWhitespaces().replacingOccurrences(of: ".", with: "", options: NSString.CompareOptions.literal, range:nil)
+        guard let intVersion = Int(versionAsString), let intBuild = Int(build.removeWhitespaces())  else {
             Logger.log(message: "Could not generate integer app version in settings")
             return nil
         }
-        // Generate based on version and build
-        let generatedVersion = (intVersion * 1000) + intBuild
         
-        return generatedVersion
+        return intVersion * 10 + intBuild
     }
     
     func refreshAuthIdpHintIfNecessary(completion: @escaping(_ appVersion: ApplicationVersionStatus)-> Void) {
@@ -360,6 +358,7 @@ class SettingsManager {
             } else if status == .isNewerThanRemote {
                 appIsBeingTested = true
             }
+            
             return completion(appIsBeingTested)
         }
     }

--- a/Myra/UI/Pages/Login/LoginViewController.swift
+++ b/Myra/UI/Pages/Login/LoginViewController.swift
@@ -64,12 +64,12 @@ class LoginViewController: BaseViewController {
         }
     }
     
-    @IBAction func hackyButton(_ sender: Any) {
-        guard let appVersion = SettingsManager.generateAppIntegerVersion() else {return}
-        API.updateRemoteVersion(ios: (appVersion), idphint: "idir") { (success) in
-            print(success)
-        }
-    }
+//    @IBAction func hackyButton(_ sender: Any) {
+//        guard let appVersion = SettingsManager.generateAppIntegerVersion() else {return}
+//        API.updateRemoteVersion(ios: (appVersion), idphint: "idir") { (success) in
+//            print(success)
+//        }
+//    }
     
     @IBAction func settingsAction(_ sender: Any) {
         let settings: Settings = UIView.fromNib()

--- a/Myra/UI/Pages/Login/LoginViewController.swift
+++ b/Myra/UI/Pages/Login/LoginViewController.swift
@@ -64,13 +64,6 @@ class LoginViewController: BaseViewController {
         }
     }
     
-//    @IBAction func hackyButton(_ sender: Any) {
-//        guard let appVersion = SettingsManager.generateAppIntegerVersion() else {return}
-//        API.updateRemoteVersion(ios: (appVersion), idphint: "idir") { (success) in
-//            print(success)
-//        }
-//    }
-    
     @IBAction func settingsAction(_ sender: Any) {
         let settings: Settings = UIView.fromNib()
         settings.initialize(fromVC: self) {


### PR DESCRIPTION

**TL;DR**

I've tweaked how app versioning is calculated so that we can switch to using semantic versioning while changing as little code as possible. I also removed the ability for the iOS app to update the (remove) version of the app. I feel better about doing this manually.

Now when you logon it will detect this version is being tested.

**The Details**

The app is using the `CFBundleShortVersionString` as a constant to compute the version number; its also using the computet version number for the Realm schema version. In our case it was `4 * 1000 + buildNumber`. When we switched to semver  for versioning it got borked because `4.0.1` was not an integer.

Now the app converts `4.0.1` to an integer by removing the `.` and we get `401`. Then the app just uses the same, but scaled down equation, to calculate the version number. Following this example it computes `401 * 10 + buildNumber`. 

I also removed the ability for the app to update the version on the server. I don't like the idea of an app inadvertently updating the server; this would impact all users the next time they authentication.